### PR TITLE
Add a temporary terminology translation table

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,3 +35,4 @@ Idris 语言文档
    proofs/index
    reference/index
    guides/index
+   terminology

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -1,0 +1,34 @@
+.. terminology
+
+##############
+中英术语对照
+##############
+
+.. table:: 对照表
+  :widths: auto
+
+  ====================   ================
+   English                中文
+  ====================   ================
+   codata types           余数据类型
+   construct              构造
+   data constructor       数据构造器
+   dependent pair         依赖序对
+   dependent record       依赖记录
+   dependent type         依赖类型
+   expression             表达式
+   family of type         类型族
+   hole                   坑
+   implicit argument      隐式参数
+   laziness               惰性
+   operator section       操作符段
+   parameterise           参数化
+   partial function       偏函数
+   pattern matching       模式匹配
+   primitive types        原语类型
+   scope                  作用域
+   total function         全函数
+   type checker           类型检查器
+   type constructor       类型构造器
+   vector                 向量
+  ====================   ================


### PR DESCRIPTION
I have drawn a terminology translation table from some of the existing translations. I believe this will be useful for translators/readers.